### PR TITLE
Bumps up pbac to latest release

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,14 +10,13 @@
   "author": "github.com/dberesford",
   "license": "MIT",
   "devDependencies": {
-    "code": "^4.0.0",
-    "eslint-config-standard": "^6.2.0",
-    "eslint-plugin-promise": "^3.0.0",
-    "eslint-plugin-standard": "^2.0.1",
-    "lab": "11.1.0"
+    "code": "4.0.0",
+    "eslint-config-standard": "6.2.0",
+    "eslint-plugin-promise": "3.0.0",
+    "eslint-plugin-standard": "2.0.1",
+    "lab": "11.2.1"
   },
   "dependencies": {
-    "open-iam": "0.0.12",
-    "pbac": "dberesford/node-pbac"
+    "pbac": "0.1.3"
   }
 }

--- a/test/foo-ownership.test.js
+++ b/test/foo-ownership.test.js
@@ -15,6 +15,7 @@ describe('Ownership', () => {
         'foo:bar:list',
         'foo:bar:read',
         'foo:bar:publish'],
+      /* eslint-disable no-template-curly-in-string */
       Resource: ['resources/${req:UserName}/*']
     }]
   }]


### PR DESCRIPTION
`pbac` has a new latest release with the @dberesford modifications in it (0.1.3)

"Downgraded" the `eslint-config-standard` to avoid the error described here https://github.com/feross/eslint-config-standard/issues/55

/cc @mihaidma @dberesford 