### PR TITLE
[spike] Add "actions" function to list actions given a resource

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const PBAC = require('pbac')
+const _ = require('lodash')
 
 module.exports = function (policies, done) {
   const pbac = new PBAC(policies)
@@ -26,7 +27,40 @@ module.exports = function (policies, done) {
     return done(null, result)
   }
 
+  function actions (resource, done) {
+    try {
+      const result = _(policies)
+        .map('Statement')
+        .flatten()
+        .filter({Effect: 'Allow'})
+        .map((statement) => {
+          let actions = []
+          statement.Resource.forEach((r) => {
+            if (pbac.conditions.StringLike(r, resource)) {
+              statement.Action.forEach((action) => {
+                process(resource, action, (err, access) => {
+                  if (err) return
+                  if (access) actions.push(action)
+                })
+              })
+            }
+          })
+
+          return actions.length > 0 ? actions : null
+        })
+        .filter()
+        .flatten()
+        .uniq()
+        .value()
+
+      return done(null, result)
+    } catch (e) {
+      return done(e)
+    }
+  }
+
   done({
-    process: process
+    process: process,
+    actions: actions
   })
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lab": "11.2.1"
   },
   "dependencies": {
+    "lodash": "^4.17.3",
     "pbac": "0.1.3"
   }
 }

--- a/test/actions.test.js
+++ b/test/actions.test.js
@@ -1,0 +1,116 @@
+const Lab = require('lab')
+const lab = exports.lab = Lab.script()
+const {describe, it, before} = lab
+const Code = require('code')
+const {expect} = Code
+const Iam = require('../lib/index.js')
+
+describe('actions function', () => {
+  let policies = [
+    {
+      Version: '2106-10-17',
+      Statement: [
+        {
+          Effect: 'Allow',
+          Action: ['foo:bar:clone',
+            'foo:bar:delete',
+            'foo:bar:list',
+            'foo:bar:read',
+            'foo:bar:publish'],
+          Resource: ['resources/thing1/*']
+        },
+        {
+          Effect: 'Deny',
+          Action: ['foo:bar:*'],
+          Resource: ['resources/nothing/*']
+        }
+      ]
+    },
+    {
+      Version: '2106-10-17',
+      Statement: [
+        {
+          Effect: 'Allow',
+          Action: ['foo:bar:read'],
+          Resource: ['resources/nothing/no-read']
+        },
+        {
+          Effect: 'Allow',
+          Action: ['foo:baz:clone',
+            'foo:baz:delete',
+            'foo:baz:list',
+            'foo:baz:read',
+            'foo:baz:publish'],
+          Resource: ['resources/multi/*']
+        }
+      ]
+    },
+    {
+      Version: '2106-10-17',
+      Statement: [{
+        Effect: 'Allow',
+        Action: ['foo:bar:clone',
+          'foo:bar:delete',
+          'foo:bar:list',
+          'foo:bar:read',
+          'foo:bar:publish'],
+        Resource: ['resources/multi/*']
+      }]
+    }
+  ]
+  let iam
+
+  before((done) => {
+    Iam(policies, (i) => {
+      expect(i).to.exist()
+
+      iam = i
+
+      done()
+    })
+  })
+
+  it('should list actions', done => {
+    iam.actions('resources/thing1/something', (err, result) => {
+      expect(err).to.not.exist()
+      expect(result).to.equal([
+        'foo:bar:clone',
+        'foo:bar:delete',
+        'foo:bar:list',
+        'foo:bar:read',
+        'foo:bar:publish'
+      ])
+
+      done()
+    })
+  })
+
+  it('should list actions that could be ok for mutiple resources', done => {
+    iam.actions('resources/multi/something', (err, result) => {
+      expect(err).to.not.exist()
+      expect(result).to.equal([
+        'foo:baz:clone',
+        'foo:baz:delete',
+        'foo:baz:list',
+        'foo:baz:read',
+        'foo:baz:publish',
+        'foo:bar:clone',
+        'foo:bar:delete',
+        'foo:bar:list',
+        'foo:bar:read',
+        'foo:bar:publish'
+      ])
+
+      done()
+    })
+  })
+
+  it('should not list denied actions', done => {
+    iam.actions('resources/nothing/no-read', (err, result) => {
+      expect(err).to.not.exist()
+      expect(result).to.equal([])
+
+      done()
+    })
+  })
+})


### PR DESCRIPTION
This PR add a new function to iam-js: `actions`.

Given a resource, the `actions` function will go through the policies and list all the actions that could be performed on that resource. This takes into consideration the `Deny`s.

I've given this implementation a try after speaking with @paolochiodi about this. I think the code is reasonable and it make sense to give `iam-js` this kind of responsibility.

**Note**: as of now the `actions` function does not accept [variables for interpolation](https://github.com/monken/node-pbac#variables)